### PR TITLE
Fixed dotfiles setup for other users side by side

### DIFF
--- a/scripts/gh.sh
+++ b/scripts/gh.sh
@@ -15,6 +15,7 @@ do_install() {
 
 	info "[gh] Install ${GH_VERSION}"
 	local gh=/tmp/gh.deb
+	sudo rm -rf ${gh}
 	download "https://github.com/cli/cli/releases/download/v${GH_VERSION}/gh_${GH_VERSION}_linux_amd64.deb" "${gh}"
 	sudo dpkg -i "${gh}"
 }

--- a/scripts/system.sh
+++ b/scripts/system.sh
@@ -48,7 +48,7 @@ do_configure() {
 	# https://github.com/ryanoasis/nerd-fonts/tree/master/patched-fonts/Meslo/L/Regular/complete
 	info "[system][configure] Install patched fonts"
 	local install_dir="/tmp/nerd-fonts"
-	rm -rf "${install_dir}" && mkdir -p "${install_dir}"
+	sudo rm -rf "${install_dir}" && mkdir -p "${install_dir}"
 	git clone --quiet --filter=blob:none --sparse "https://github.com/ryanoasis/nerd-fonts.git" "${install_dir}"
 	(
 		cd "${install_dir}"


### PR DESCRIPTION
If other user on the same system trying to setup dotfiles it'll fail due
to some folders/files created by other user and not cleane up.

So I've added sudo in several places to make setup more resilient.
